### PR TITLE
Closes Inventory When Item is Used

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -3,6 +3,7 @@ VORP = exports.vorp_inventory:vorp_inventoryApi()
 
 VORP.RegisterUsableItem(Config.FixItem, function(data)
 	VORP.subItem(data.source, Config.FixItem, 1)
+	VORP.CloseInv(data.source)
 	TriggerClientEvent('flat:FixWagon', data.source)
 end)
 


### PR DESCRIPTION
When repair item was used, it would not close the player inventory which conflicted with interacting with the mini game. This pull request fixes that issue by adding `VORP.CloseInv(data.source)` to ln 6 of server.lua. Now when a player uses the repair item, it closes the player inventory then triggers the minigame. 